### PR TITLE
Minor Kotlin cleanups

### DIFF
--- a/assertk-coroutines/src/commonTest/kotlin/test/assertk/coroutines/assertions/AnyTest.kt
+++ b/assertk-coroutines/src/commonTest/kotlin/test/assertk/coroutines/assertions/AnyTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertFailsWith
 import kotlinx.coroutines.test.runTest
 
 class AnyTest {
-    val subject = BasicObject("test")
+    private val subject = BasicObject("test")
 
     @Test
     fun suspendCall_passes() = runTest {

--- a/assertk/build.gradle.kts
+++ b/assertk/build.gradle.kts
@@ -1,7 +1,4 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
-import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
-import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.common
-import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.wasm
 
 plugins {
     id("assertk.multiplatform")

--- a/assertk/src/commonMain/kotlin/assertk/assert.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assert.kt
@@ -29,7 +29,7 @@ sealed class Assert<out T>(val name: String?, internal val context: AssertingCon
                     assertThat(transform(value), name)
                 } catch (e: Throwable) {
                     notifyFailure(e)
-                    failing<R>(e, name)
+                    failing(e, name)
                 }
             }
             is FailingAssert -> failing(error, name)

--- a/assertk/src/commonMain/kotlin/assertk/assertions/array.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/array.kt
@@ -58,7 +58,7 @@ fun Assert<Array<*>>.isNotEmpty() = given { actual ->
  * @see [isEmpty]
  */
 fun Assert<Array<*>?>.isNullOrEmpty() = given { actual ->
-    if (actual == null || actual.isEmpty()) return
+    if (actual.isNullOrEmpty()) return
     expected("to be null or empty but was:${show(actual)}")
 }
 

--- a/assertk/src/commonMain/kotlin/assertk/assertions/collection.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/collection.kt
@@ -32,7 +32,7 @@ fun Assert<Collection<*>>.isNotEmpty() = given { actual ->
  * @see [isEmpty]
  */
 fun Assert<Collection<*>?>.isNullOrEmpty() = given { actual ->
-    if (actual == null || actual.isEmpty()) return
+    if (actual.isNullOrEmpty()) return
     expected("to be null or empty but was:${show(actual)}")
 }
 

--- a/assertk/src/commonMain/kotlin/assertk/assertions/map.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/map.kt
@@ -34,7 +34,7 @@ fun Assert<Map<*, *>>.isNotEmpty() = given { actual ->
  * @see [isEmpty]
  */
 fun Assert<Map<*, *>?>.isNullOrEmpty() = given { actual ->
-    if (actual == null || actual.isEmpty()) return
+    if (actual.isNullOrEmpty()) return
     expected("to be null or empty but was:${show(actual)}")
 }
 

--- a/assertk/src/commonMain/kotlin/assertk/assertions/support/support.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/support/support.kt
@@ -14,7 +14,7 @@ import assertk.fail
 fun show(value: Any?, wrap: String = "<>"): String =
     "${prefix(wrap)}${display(value)}${suffix(wrap)}"
 
-private fun prefix(wrap: String): String = if (wrap.length > 0) wrap[0].toString() else ""
+private fun prefix(wrap: String): String = if (wrap.isNotEmpty()) wrap[0].toString() else ""
 private fun suffix(wrap: String): String = if (wrap.length > 1) wrap[1].toString() else ""
 
 @Suppress("ComplexMethod")

--- a/assertk/src/commonMain/kotlin/assertk/assertions/throwable.kt
+++ b/assertk/src/commonMain/kotlin/assertk/assertions/throwable.kt
@@ -1,7 +1,6 @@
 package assertk.assertions
 
 import assertk.Assert
-import assertk.ValueAssert
 import assertk.all
 
 /**

--- a/assertk/src/commonMain/kotlin/assertk/collection.kt
+++ b/assertk/src/commonMain/kotlin/assertk/collection.kt
@@ -16,11 +16,11 @@ private class CollectionFailure<T>(
     private val failures: MutableMap<Int, MutableList<Throwable>> = LinkedHashMap()
 
     override fun fail(error: Throwable) {
-        failures.getOrPut(index, { ArrayList() }).plusAssign(error)
+        failures.getOrPut(index) { ArrayList() }.plusAssign(error)
     }
 
     override fun invoke() {
-        CollectionCheck<T>(collectedItems, failures).check()
+        CollectionCheck(collectedItems, failures).check()
     }
 }
 

--- a/assertk/src/commonMain/kotlin/assertk/failure.kt
+++ b/assertk/src/commonMain/kotlin/assertk/failure.kt
@@ -4,7 +4,6 @@ import assertk.Failure.Companion.soft
 import com.willowtreeapps.opentest4k.AssertionFailedError
 import com.willowtreeapps.opentest4k.MultipleFailuresError
 import com.willowtreeapps.opentest4k.failures
-import kotlin.DeprecationLevel.HIDDEN
 
 /**
  * Assertions are run in a failure context which captures failures to report them.

--- a/assertk/src/commonMain/kotlin/assertk/table.kt
+++ b/assertk/src/commonMain/kotlin/assertk/table.kt
@@ -6,7 +6,7 @@ private class TableFailure(private val table: Table) : Failure {
     private val failures: MutableMap<Int, MutableList<Throwable>> = LinkedHashMap()
 
     override fun fail(error: Throwable) {
-        failures.getOrPut(table.index, { ArrayList() }).plusAssign(error)
+        failures.getOrPut(table.index) { ArrayList() }.plusAssign(error)
     }
 
     override fun invoke() {
@@ -24,7 +24,7 @@ internal class TableFailuresError(
     private val table: Table,
     private val errors: Map<Int, List<Throwable>>
 ) : AssertionError() {
-    override val message: String?
+    override val message: String
         get() {
             val errorCount = errors.map { it.value.size }.sum()
             val prefix = if (errorCount == 1) {

--- a/assertk/src/commonTest/kotlin/test/assertk/FailureTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/FailureTest.kt
@@ -1,9 +1,5 @@
 package test.assertk
 
-import assertk.assertThat
-import assertk.assertions.hasMessage
-import assertk.assertions.isFailure
-import assertk.assertions.isInstanceOf
 import assertk.fail
 import com.willowtreeapps.opentest4k.*
 import kotlin.test.*

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/AnyTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/AnyTest.kt
@@ -8,8 +8,9 @@ import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 
 class AnyTest {
-    val subject = BasicObject("test")
-    val nullableSubject: BasicObject? = BasicObject("test")
+    private val subject = BasicObject("test")
+    @Suppress("RedundantNullableReturnType")
+    private val nullableSubject: BasicObject? = BasicObject("test")
 
     @Test
     fun extracts_kClass() {
@@ -585,11 +586,11 @@ class AnyTest {
 
         class DifferentObject : TestObject()
 
-        class Expected(val value: String) {
+        class Expected(private val value: String) {
             override fun toString() = value
         }
 
-        class Actual(val value: String) {
+        class Actual(private val value: String) {
             override fun toString() = value
         }
     }

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/ListTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/ListTest.kt
@@ -4,7 +4,6 @@ import assertk.assertThat
 import assertk.assertions.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 
 class ListTest {

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/ThrowableTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/ThrowableTest.kt
@@ -8,9 +8,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class ThrowableTest {
-    val rootCause = Exception("rootCause")
-    val cause = Exception("cause", rootCause)
-    val subject = Exception("test", cause)
+    private val rootCause = Exception("rootCause")
+    private val cause = Exception("cause", rootCause)
+    private val subject = Exception("test", cause)
 
     @Test
     fun extracts_message() {

--- a/assertk/src/commonTest/kotlin/test/assertk/assertions/support/SupportTest.kt
+++ b/assertk/src/commonTest/kotlin/test/assertk/assertions/support/SupportTest.kt
@@ -1,8 +1,6 @@
 package test.assertk.assertions.support
 
 import assertk.assertThat
-import assertk.assertions.hasMessage
-import assertk.assertions.isEqualTo
 import assertk.assertions.isFailure
 import assertk.assertions.isSuccess
 import assertk.assertions.message

--- a/assertk/src/jvmMain/kotlin/assertk/assertions/file.kt
+++ b/assertk/src/jvmMain/kotlin/assertk/assertions/file.kt
@@ -113,7 +113,6 @@ fun Assert<File>.hasExtension(expected: String) {
 /**
  * Asserts the file contains exactly the expected text (and nothing else).
  * @param charset The character set of the file, default is [Charsets.UTF_8]
- * @see [hasBytes]
  */
 fun Assert<File>.hasText(expected: String, charset: Charset = Charsets.UTF_8) {
     text(charset).isEqualTo(expected)

--- a/assertk/src/jvmMain/kotlin/assertk/assertions/inputstream.kt
+++ b/assertk/src/jvmMain/kotlin/assertk/assertions/inputstream.kt
@@ -25,10 +25,7 @@ fun Assert<InputStream>.hasSameContentAs(expected: InputStream) = given { actual
  * @param expected which content is compared to the actual one
  */
 fun Assert<InputStream>.hasNotSameContentAs(expected: InputStream) = given { actual ->
-    val msg = doTheStreamHaveTheSameContent(actual, expected)
-    if (msg == null) {
-        expected("streams not to be equal, but they were equal")
-    }
+    doTheStreamHaveTheSameContent(actual, expected) ?: expected("streams not to be equal, but they were equal")
 }
 
 private const val BUFFER_SIZE = 4096
@@ -113,7 +110,7 @@ private fun doTheStreamHaveTheSameContent(actual: InputStream, expected: InputSt
                         " but actual stream size ($actualSize) differs from other stream size ($otherSize)"
             }
 
-            val pos = compare(Math.min(actualRead, otherRead), actualBuffer, otherBuffer)
+            val pos = compare(actualRead.coerceAtMost(otherRead), actualBuffer, otherBuffer)
             val actualSize = consume(actual) + actualRead + size
             val otherSize = consume(expected) + otherRead + size
 

--- a/assertk/src/jvmMain/kotlin/assertk/failure.kt
+++ b/assertk/src/jvmMain/kotlin/assertk/failure.kt
@@ -7,7 +7,6 @@ internal actual inline fun failWithNotInStacktrace(error: Throwable): Nothing {
     val filtered = error.stackTrace
         .dropWhile { it.className.startsWith("assertk") }
         .toTypedArray()
-    @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UnsafeCast")
     error.stackTrace = filtered
     throw error
 }

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/FileTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/FileTest.kt
@@ -8,8 +8,8 @@ import kotlin.test.*
 
 class FileTest {
 
-    val file = File.createTempFile("exists", "txt")
-    val directory = Files.createTempDirectory("isDirectory").toFile()
+    private val file = File.createTempFile("exists", "txt")
+    private val directory = Files.createTempDirectory("isDirectory").toFile()
 
     //region exists
     @Test
@@ -76,8 +76,8 @@ class FileTest {
     //endregion
 
     //region hasName
-    val namedFile = File("assertKt/file.txt")
-    val namedDirectory = File("assertKt/directory")
+    private val namedFile = File("assertKt/file.txt")
+    private val namedDirectory = File("assertKt/directory")
 
     @Test
     fun hasName_correct_value_file_passes() {
@@ -113,7 +113,7 @@ class FileTest {
     //endregion
 
     //region hasPath
-    val fileWithPath = File("assertKt/file.txt")
+    private val fileWithPath = File("assertKt/file.txt")
 
     @Test
     fun hasPath_correct_path_passes() {
@@ -133,7 +133,7 @@ class FileTest {
     //endregion
 
     //region hasParent
-    val fileWithParent = File("assertKt/directory/file.txt")
+    private val fileWithParent = File("assertKt/directory/file.txt")
 
     @Test
     fun hasParent_correct_parent_passes() {
@@ -157,7 +157,7 @@ class FileTest {
     //endregion
 
     //region hasExtension
-    val fileWithExtension = File("file.txt")
+    private val fileWithExtension = File("file.txt")
 
     @Test
     fun hasExtension_correct_extension_passes() {
@@ -177,8 +177,8 @@ class FileTest {
     //endregion
 
     //region hasText
-    val fileWithText = File.createTempFile("file_contains", ".txt")
-    val text =
+    private val fileWithText = File.createTempFile("file_contains", ".txt")
+    private val text =
         "The Answer to the Great Question... Of Life, the Universe and Everything... Is... Forty-two,' said Deep Thought, with infinite majesty and calm."
 
     @BeforeTest
@@ -218,8 +218,8 @@ class FileTest {
     //endregion
 
     //region matches
-    val matchingFile = File.createTempFile("file_contains", ".txt")
-    val matchingText = "Matches"
+    private val matchingFile = File.createTempFile("file_contains", ".txt")
+    private val matchingText = "Matches"
 
     @BeforeTest
     fun setupMatchingFile() {
@@ -243,8 +243,8 @@ class FileTest {
     //endregion
 
     //region hasDirectChild
-    val directoryWithChild = Files.createTempDirectory("isDirectory").toFile()
-    val childFile = File.createTempFile("file", ".txt", directoryWithChild)
+    private val directoryWithChild = Files.createTempDirectory("isDirectory").toFile()
+    private val childFile = File.createTempFile("file", ".txt", directoryWithChild)
 
     @Test
     fun hasDirectChild_value_is_child_passes() {

--- a/assertk/src/jvmTest/kotlin/test/assertk/assertions/JavaAnyTest.kt
+++ b/assertk/src/jvmTest/kotlin/test/assertk/assertions/JavaAnyTest.kt
@@ -4,15 +4,13 @@ import assertk.assertThat
 import assertk.assertions.*
 import test.assertk.opentestPackageName
 import java.lang.Exception
-import kotlin.reflect.KCallable
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 
 class JavaAnyTest {
-    val p: String = JavaAnyTest::class.java.name
-    val subject = BasicObject("test")
+    private val p: String = JavaAnyTest::class.java.name
+    private val subject = BasicObject("test")
 
     //region jClass
     @Test
@@ -187,7 +185,7 @@ class JavaAnyTest {
         val int: Int = 42,
         val double: Double = 3.14,
         val other: BasicObject? = null,
-        private val private: Int = 0,
+        private val private: Int = 0
     ) : TestObject() {
         val failing: String get() = throw Exception("sorry!")
 

--- a/assertk/src/nativeMain/kotlin/assertk/failure.kt
+++ b/assertk/src/nativeMain/kotlin/assertk/failure.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package assertk
 
 internal actual inline fun failWithNotInStacktrace(error: Throwable): Nothing {

--- a/assertk/src/nativeTest/kotlin/test/assertk/NativeAssertAllTest.kt
+++ b/assertk/src/nativeTest/kotlin/test/assertk/NativeAssertAllTest.kt
@@ -60,8 +60,8 @@ class NativeAssertAllTest {
         assertFalse(runs)
     }
 
-    fun aBunchOfWokers(f: (Worker) -> Future<Unit>) {
-        val workers = Array(20, { Worker.start() })
+    private fun aBunchOfWokers(f: (Worker) -> Future<Unit>) {
+        val workers = Array(20) { Worker.start() }
         val futures = mutableSetOf<Future<Unit>>()
         for (i in 0..5) {
             for (w in workers) {

--- a/buildSrc/src/main/kotlin/assertk.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/assertk.publish.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.dokka.gradle.DokkaTask
-import java.util.Locale
 
 plugins {
     `maven-publish`


### PR DESCRIPTION
- Replace `isNullOrEmpty` with the implementations in stdlib.
- Replace some other implementations.
- Remove redundant generic types.
- Move out lambda params.
- Replace nullable return values.
- Add private modifiers.
- Remove unused comment refs.
- Remove unnecessary suppression.
- Remove unused imports.